### PR TITLE
feat: add notifications for stalled lows

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ If you are using a CGM with support for instant glucose, also add the
 - http://host.docker.internal:6501/instant-new
 - check "include last"
 
+### Support for Low Changed
+
+Also add the `low:changed` webhook:
+
+- http://host.docker.internal:6501/low
+- check "include last"
+
 ### Configuration
 
 Copy the file `sample/config.mjs` in the root of the repository and use it as a starting point:

--- a/README.md
+++ b/README.md
@@ -40,3 +40,20 @@ cp sample/config.mjs .
 ```
 
 By default, the config will send notifications when low/high events occur, when you return in the normal range, and will send repeat notifications for lows.
+
+## Snoozing non-low notifications
+
+You can temporarily silence every non-low notification (high alerts, end-of-low, end-of-high, instant updates, still-high reminders) until a given date and time. Low alerts are never affected. Snoozed glucose-changed events still ship a silent badge update so the app icon keeps the latest value.
+
+The snooze state is stored on the OpenGluck server under the `apn-snooze` userdata key, so it survives webhook restarts and can be set from any machine that has `OPENGLUCK_URL` and `OPENGLUCK_TOKEN` configured.
+
+```bash
+# Snooze until a specific date/time (any format new Date() accepts)
+npm run snooze -- 2026-04-27T20:10+00:00
+
+# Show the current snooze (also prints the time in your local timezone)
+npm run snooze
+
+# Clear the snooze
+npm run snooze -- clear
+```

--- a/README.md
+++ b/README.md
@@ -18,15 +18,11 @@ opengluck](https://<your-server>/webhooks/glucose:changed):
 
 ### Support for Instant Glucose
 
-If you are using a CGM with support for instant glucose, you might also want to
-enable the `/instant` route. This will update the badge more often, using a
-lesser priority to preserve battery life for these updates.
+If you are using a CGM with support for instant glucose, also add the
+`instant-glucose:new` webhook:
 
-To do so, [install the `instant-glucose:changed` webhook in
-opengluck](https://<your-server>/webhooks/instant-glucose:changed):
-
-- http://host.docker.internal:6501/instant
-- enable sending last data
+- http://host.docker.internal:6501/instant-new
+- check "include last"
 
 ### Configuration
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const port = Number(process.env.PORT || 6501);
       const isGlucoseChanged = req.url === "/";
       const isInstant = req.url === "/instant";
       const isInstantNew = req.url === "/instant-new";
+      const isLowChanged = req.url === "/low";
       const bodyJSON = Buffer.concat(chunks).toString();
       console.log("Received", bodyJSON);
       const body = JSON.parse(bodyJSON);
@@ -51,6 +52,11 @@ const port = Number(process.env.PORT || 6501);
 
       if (isInstant) {
         // deprecated, we now use isInstantNew
+        return;
+      }
+
+      if (isLowChanged) {
+        await additionalConfig.default({ url: req.url, data, last, notification });
         return;
       }
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ const port = Number(process.env.PORT || 6501);
     req.on("data", (chunk) => chunks.push(chunk));
     req.on("end", async () => {
       console.log(`Received payload at ${new Date()}`);
+      const isGlucoseChanged = req.url === "/";
       const isInstant = req.url === "/instant";
+      const isInstantNew = req.url === "/instant-new";
       const bodyJSON = Buffer.concat(chunks).toString();
       console.log("Received", bodyJSON);
       const body = JSON.parse(bodyJSON);
@@ -33,17 +35,24 @@ const port = Number(process.env.PORT || 6501);
       console.log("Parsed last", last);
       res.end("OK");
 
-      const newGlucose = data.new.mgDl;
-      const newTimestamp = data.new.timestamp;
+      const newGlucose = data.mgDl ?? data.new.mgDl;
+      const newTimestamp = data.timestamp ?? data.new.timestamp;
       const newDate = new Date(newTimestamp);
       const cgmProperties = data["cgm-properties"] || {};
       const glucoseRecords = last["glucose-records"] || [];
-      const isNewScanOrHistoric = glucoseRecords.some(record => new Date(record.timestamp).getTime() === newDate.getTime());
+      const isNewScanOrHistoric = glucoseRecords.some(
+        (record) => new Date(record.timestamp).getTime() === newDate.getTime(),
+      );
       const currentCgmHasRealTime = !!cgmProperties["has-real-time"];
 
       console.log(
-        `isInstant=${isInstant}, cgmProperties=${cgmProperties}, currentDeviceHasCgmRealtimeData=${currentCgmHasRealTime}, newTimestamp=${newTimestamp}, isNewScanOrHistoric=${isNewScanOrHistoric}`,
+        `isGlucoseChanged=${isGlucoseChanged} isInstant=${isInstant} isInstantNew=${isInstantNew}, cgmProperties=${cgmProperties}, currentDeviceHasCgmRealtimeData=${currentCgmHasRealTime}, newTimestamp=${newTimestamp}, isNewScanOrHistoric=${isNewScanOrHistoric}`,
       );
+
+      if (isInstant) {
+        // deprecated, we now use isInstantNew
+        return;
+      }
 
       // sending notification
       let notification = {};
@@ -58,7 +67,7 @@ const port = Number(process.env.PORT || 6501);
         isNewScanOrHistoric,
       };
       if (!isInstant) {
-        await additionalConfig.default({ data, last, notification });
+        await additionalConfig.default({ url: req.url, data, last, notification });
       }
       console.log("Will send notification:", notification);
       await sendNotification(notification);

--- a/index.js
+++ b/index.js
@@ -78,6 +78,18 @@ const port = Number(process.env.PORT || 6501);
           return;
         }
       }
+      const snoozedUntil = additionalConfig.shouldSnooze
+        ? await additionalConfig.shouldSnooze(notification)
+        : null;
+      if (snoozedUntil) {
+        console.log(
+          `snoozing this type of notification until ${snoozedUntil}, sending silent badge update`,
+        );
+        delete notification.alert;
+        delete notification.sound;
+        notification.contentAvailable = true;
+        notification.priority = 5;
+      }
       console.log("Will send notification:", notification);
       await sendNotification(notification);
     });

--- a/index.js
+++ b/index.js
@@ -36,6 +36,11 @@ const port = Number(process.env.PORT || 6501);
       console.log("Parsed last", last);
       res.end("OK");
 
+      if (isLowChanged) {
+        await additionalConfig.default({ url: req.url, data, last });
+        return;
+      }
+
       const newGlucose = data.mgDl ?? data.new.mgDl;
       const newTimestamp = data.timestamp ?? data.new.timestamp;
       const newDate = new Date(newTimestamp);
@@ -58,10 +63,6 @@ const port = Number(process.env.PORT || 6501);
       // sending notification
       let notification = {};
 
-      if (isLowChanged) {
-        await additionalConfig.default({ url: req.url, data, last, notification });
-        return;
-      }
       notification.contentAvailable = !isInstant;
       notification.priority = isInstant ? 5 : 10;
       notification.sound = "default";

--- a/index.js
+++ b/index.js
@@ -55,13 +55,13 @@ const port = Number(process.env.PORT || 6501);
         return;
       }
 
+      // sending notification
+      let notification = {};
+
       if (isLowChanged) {
         await additionalConfig.default({ url: req.url, data, last, notification });
         return;
       }
-
-      // sending notification
-      let notification = {};
       notification.contentAvailable = !isInstant;
       notification.priority = isInstant ? 5 : 10;
       notification.sound = "default";
@@ -73,7 +73,10 @@ const port = Number(process.env.PORT || 6501);
         isNewScanOrHistoric,
       };
       if (!isInstant) {
-        await additionalConfig.default({ url: req.url, data, last, notification });
+        const result = await additionalConfig.default({ url: req.url, data, last, notification });
+        if (result && result.skip) {
+          return;
+        }
       }
       console.log("Will send notification:", notification);
       await sendNotification(notification);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "TZ=Europe/Paris node index.js",
     "test": "echo \"Error: no test specified\" && exit 1",
+    "snooze": "node scripts/snooze.js",
     "eslint": "eslint **.js **.mjs"
   },
   "author": "",

--- a/sample/config.mjs
+++ b/sample/config.mjs
@@ -45,6 +45,39 @@ setInterval(function () {
   timezoneShift = getTimezoneShift();
 }, 300e3);
 
+async function getSnoozedUntil() {
+  return new Promise((resolve) => {
+    const req = request(
+      `${process.env.OPENGLUCK_URL}/opengluck/userdata/apn-snooze`,
+      (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => {
+          try {
+            const parsed = JSON.parse(
+              Buffer.concat(chunks).toString() || "null",
+            );
+            const until = parsed?.until;
+            if (!until) return resolve(null);
+            resolve(new Date(until).getTime() > Date.now() ? until : null);
+          } catch {
+            resolve(null);
+          }
+        });
+        res.on("error", () => resolve(null));
+      },
+    );
+    req.on("error", () => resolve(null));
+    req.setHeader("Authorization", `Bearer ${process.env.OPENGLUCK_TOKEN}`);
+    req.end();
+  });
+}
+
+export async function shouldSnooze(notification) {
+  if (notification?.category === "LOW") return null;
+  return await getSnoozedUntil();
+}
+
 function convertMillisecondsToHoursAndMinutesString(milliseconds) {
   const hours = Math.floor(milliseconds / 3600000);
   const minutes = Math.floor((milliseconds % 3600000) / 60000);
@@ -173,6 +206,11 @@ setInterval(async () => {
     )}`,
     body: "Check your blood glucose.",
   };
+  const snoozedUntil = await shouldSnooze(notification);
+  if (snoozedUntil) {
+    console.log(`snoozing this type of notification until ${snoozedUntil}`);
+    return;
+  }
   console.log("Will send notification:", notification);
   await sendNotification(notification);
 }, 60e3);
@@ -237,6 +275,11 @@ setInterval(async () => {
     };
   }
 
+  const snoozedUntil = await shouldSnooze(notification);
+  if (snoozedUntil) {
+    console.log(`snoozing this type of notification until ${snoozedUntil}`);
+    return;
+  }
   console.log("Will send stalled low notification:", notification);
   await sendNotification(notification);
 }, 60e3);

--- a/sample/config.mjs
+++ b/sample/config.mjs
@@ -191,7 +191,6 @@ setInterval(async () => {
     return;
   }
   const stalledFor = Date.now() - lastReceivedAt;
-  console.log(`Stalled low check: lastMgDl=${lastMgDl}, stalledFor=${Math.round(stalledFor / 1000)}s, lastReceivedAt=${lastReceivedAt}`);
   if (stalledFor < 90e3) {
     return;
   }

--- a/sample/config.mjs
+++ b/sample/config.mjs
@@ -191,6 +191,7 @@ setInterval(async () => {
     return;
   }
   const stalledFor = Date.now() - lastReceivedAt;
+  console.log(`Stalled low check: lastMgDl=${lastMgDl}, stalledFor=${Math.round(stalledFor / 1000)}s, lastReceivedAt=${lastReceivedAt}`);
   if (stalledFor < 90e3) {
     return;
   }

--- a/sample/config.mjs
+++ b/sample/config.mjs
@@ -144,7 +144,7 @@ setInterval(async () => {
   }
   const highNoticeSince = getTimestampOfEvent("high-notice");
   const highNoticeSinceDuration = highNoticeSince
-    ? (Date.now() - highNoticeSince) / 1e3
+    ? Date.now() - highNoticeSince
     : null;
   console.log(
     `highNoticeSince=${highNoticeSince}, highSinceNoticeDuration=${highNoticeSinceDuration}`,
@@ -152,7 +152,7 @@ setInterval(async () => {
   if (highNoticeSinceDuration && highNoticeSinceDuration < 3600e3) {
     console.log(
       `Skip sending still high notice, last notice was sent ${Math.round(
-        highNoticeSinceDuration / 60,
+        highNoticeSinceDuration / 60e3,
       )} minutes ago`,
     );
     return;
@@ -194,18 +194,46 @@ setInterval(async () => {
   if (stalledFor < 90e3) {
     return;
   }
+
+  // skip if a recent low event exists (user already knows)
+  if (hasRecentLowRecord()) {
+    console.log("Skip sending stall notification, recent low event exists");
+    return;
+  }
+
+  const lastInstantMgDl = readTmpData("lastInstantMgDl");
+  const lastInstantAt = readTmpData("lastInstantAt");
+  const instantIsRecent = lastInstantAt && (Date.now() - lastInstantAt) < 90e3;
+
+  // if recent instant glucose is >= 70, we're out of hypo, skip
+  if (instantIsRecent && lastInstantMgDl >= 70) {
+    console.log("Skip sending stall notification, recent instant glucose is >= 70 mg/dL");
+    return;
+  }
+
   const sinceMinutes = convertMillisecondsToHoursAndMinutesString(
     Date.now() - lowSince.getTime()
   );
+  const stalledForStr = convertMillisecondsToHoursAndMinutesString(stalledFor);
   let notification = {};
   notification.priority = 10;
   notification.sound = "default";
   notification.badge = lastMgDl;
   notification.category = "LOW";
-  notification.alert = {
-    title: `\u{1F6A8} Still Low, Since ${sinceMinutes}`,
-    body: `Stalled at ${lastMgDl} mg/dL`,
-  };
+
+  if (instantIsRecent) {
+    // we have recent instant glucose, so we haven't truly stalled
+    notification.alert = {
+      title: `\u{1F6A8} Still Low, Since ${sinceMinutes}`,
+      body: `${lastInstantMgDl} mg/dL`,
+    };
+  } else {
+    notification.alert = {
+      title: `\u{1F6A8} Still Low, Since ${sinceMinutes}`,
+      body: `Stalled for ${stalledForStr} at ${lastMgDl} mg/dL`,
+    };
+  }
+
   console.log("Will send stalled low notification:", notification);
   await sendNotification(notification);
 }, 60e3);
@@ -214,12 +242,35 @@ function hasRecentLow(last) {
   const lowRecords = last["low-records"] || [];
   return lowRecords.some((record) => {
     const elapsed = new Date() - new Date(record.timestamp);
-    console.log("DEBUG elapsed since low record:", elapsed); // TODO remove this
     return elapsed < 30 * 60e3;
   });
 }
 
-export default async function showAlert({ data, last, notification }) {
+function hasRecentLowRecord() {
+  const lowRecords = readTmpData("lowRecords") || [];
+  return lowRecords.some((record) => {
+    const elapsed = Date.now() - new Date(record.timestamp).getTime();
+    const threshold = record.sugar_in_grams ? 30 * 60e3 : 10 * 60e3;
+    return elapsed < threshold;
+  });
+}
+
+export default async function showAlert({ url, data, last, notification }) {
+  // store low-records from every webhook for stall interval use
+  if (last && last["low-records"]) {
+    writeTmpData("lowRecords", last["low-records"]);
+  }
+
+  if (url === "/instant-new") {
+    writeTmpData("lastInstantMgDl", data.mgDl);
+    writeTmpData("lastInstantAt", Date.now());
+    notification.contentAvailable = false;
+    notification.priority = 5;
+    delete notification.sound;
+    delete notification.alert;
+    return;
+  }
+
   const newMgDl = data.new.mgDl;
   const newTimestamp = data.new.timestamp;
   const previousMgDl = data.previous.mgDl;

--- a/sample/config.mjs
+++ b/sample/config.mjs
@@ -263,10 +263,20 @@ export default async function showAlert({ url, data, last, notification }) {
     writeTmpData("lowRecords", last["low-records"]);
   }
 
+  if (url === "/low") {
+    console.log(`low: low-records=${JSON.stringify(last["low-records"])}`);
+    return;
+  }
+
   if (url === "/instant-new") {
     console.log(`instant-new: mgDl=${data.mgDl}, timestamp=${data.timestamp}`);
-    writeTmpData("lastInstantMgDl", data.mgDl);
-    writeTmpData("lastInstantAt", Date.now());
+    const previousInstantTimestamp = readTmpData("lastInstantTimestamp");
+    const newInstantTimestamp = new Date(data.timestamp).getTime();
+    if (!previousInstantTimestamp || newInstantTimestamp >= previousInstantTimestamp) {
+      writeTmpData("lastInstantMgDl", data.mgDl);
+      writeTmpData("lastInstantAt", Date.now());
+      writeTmpData("lastInstantTimestamp", newInstantTimestamp);
+    }
     notification.contentAvailable = false;
     notification.priority = 5;
     delete notification.sound;

--- a/sample/config.mjs
+++ b/sample/config.mjs
@@ -34,6 +34,7 @@ async function getTimezoneShift() {
         res.on("error", reject);
       },
     );
+    req.on("error", reject);
     req.setHeader("Authorization", `Bearer ${process.env.OPENGLUCK_TOKEN}`);
     req.end();
   });
@@ -276,6 +277,9 @@ export default async function showAlert({ url, data, last, notification }) {
       writeTmpData("lastInstantMgDl", data.mgDl);
       writeTmpData("lastInstantAt", Date.now());
       writeTmpData("lastInstantTimestamp", newInstantTimestamp);
+    } else {
+      console.log(`instant-new: skipping old record (${data.timestamp} < ${new Date(previousInstantTimestamp).toISOString()})`);
+      return { skip: true };
     }
     notification.contentAvailable = false;
     notification.priority = 5;

--- a/sample/config.mjs
+++ b/sample/config.mjs
@@ -203,7 +203,9 @@ setInterval(async () => {
 
   const lastInstantMgDl = readTmpData("lastInstantMgDl");
   const lastInstantAt = readTmpData("lastInstantAt");
-  const instantIsRecent = lastInstantAt && (Date.now() - lastInstantAt) < 90e3;
+  const instantAge = lastInstantAt ? Date.now() - lastInstantAt : null;
+  const instantIsRecent = instantAge !== null && instantAge < 90e3;
+  console.log(`Stall check: lastMgDl=${lastMgDl}, stalledFor=${stalledFor}ms, instantMgDl=${lastInstantMgDl}, instantAge=${instantAge}ms, instantIsRecent=${instantIsRecent}`);
 
   // if recent instant glucose is >= 70, we're out of hypo, skip
   if (instantIsRecent && lastInstantMgDl >= 70) {
@@ -262,6 +264,7 @@ export default async function showAlert({ url, data, last, notification }) {
   }
 
   if (url === "/instant-new") {
+    console.log(`instant-new: mgDl=${data.mgDl}, timestamp=${data.timestamp}`);
     writeTmpData("lastInstantMgDl", data.mgDl);
     writeTmpData("lastInstantAt", Date.now());
     notification.contentAvailable = false;

--- a/sample/config.mjs
+++ b/sample/config.mjs
@@ -176,6 +176,40 @@ setInterval(async () => {
   await sendNotification(notification);
 }, 60e3);
 
+setInterval(async () => {
+  // check if we are still low and have not received a new reading in over 90s
+  const lastMgDl = readTmpData("lastMgDl");
+  if (!isLow(lastMgDl)) {
+    return;
+  }
+  const lowSince = getTimestampOfEvent("low");
+  if (!lowSince) {
+    return;
+  }
+  const lastReceivedAt = readTmpData("lastReceivedAt");
+  if (!lastReceivedAt) {
+    return;
+  }
+  const stalledFor = Date.now() - lastReceivedAt;
+  if (stalledFor < 90e3) {
+    return;
+  }
+  const sinceMinutes = convertMillisecondsToHoursAndMinutesString(
+    Date.now() - lowSince.getTime()
+  );
+  let notification = {};
+  notification.priority = 10;
+  notification.sound = "default";
+  notification.badge = lastMgDl;
+  notification.category = "LOW";
+  notification.alert = {
+    title: `\u{1F6A8} Still Low, Since ${sinceMinutes}`,
+    body: `Stalled at ${lastMgDl} mg/dL`,
+  };
+  console.log("Will send stalled low notification:", notification);
+  await sendNotification(notification);
+}, 60e3);
+
 function hasRecentLow(last) {
   const lowRecords = last["low-records"] || [];
   return lowRecords.some((record) => {
@@ -196,6 +230,8 @@ export default async function showAlert({ data, last, notification }) {
     `isNight=${isNight}, hasRealTime=${hasRealTime}, isLowKnown=${isLowKnown}`,
   );
   writeTmpData("hasRealTime", hasRealTime);
+  writeTmpData("lastReceivedAt", Date.now());
+  writeTmpData("lastMgDl", newMgDl);
   var lastHighTimestamp = getTimestampOfEvent("high");
   if (!isHigh(newMgDl)) {
     setTimestampOfEvent("high-notice", "");

--- a/scripts/snooze.js
+++ b/scripts/snooze.js
@@ -1,0 +1,72 @@
+const { getUserdata, setUserdata } = require("opengluck-node-client");
+
+function formatDuration(ms) {
+  const sign = ms < 0 ? "-" : "";
+  const abs = Math.abs(ms);
+  const days = Math.floor(abs / 86400000);
+  const hours = Math.floor((abs % 86400000) / 3600000);
+  const minutes = Math.floor((abs % 3600000) / 60000);
+  const parts = [];
+  if (days) parts.push(`${days}d`);
+  if (hours) parts.push(`${hours}h`);
+  if (minutes || !parts.length) parts.push(`${minutes}m`);
+  return sign + parts.join(" ");
+}
+
+function formatLocal(date) {
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const local = date.toLocaleString("sv-SE", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  return `${local} ${tz}`;
+}
+
+(async () => {
+  const arg = process.argv[2];
+
+  if (!arg) {
+    const current = await getUserdata("apn-snooze");
+    const until = current?.until;
+    if (!until) {
+      console.log("No active snooze");
+      return;
+    }
+    const untilDate = new Date(until);
+    const untilMs = untilDate.getTime();
+    const now = Date.now();
+    if (untilMs > now) {
+      console.log(
+        `Currently snoozing non-low notifications until ${until} (${formatLocal(untilDate)}, ${formatDuration(untilMs - now)} remaining)`,
+      );
+    } else {
+      console.log(
+        `No active snooze (last snooze expired ${until}, ${formatLocal(untilDate)})`,
+      );
+    }
+    return;
+  }
+
+  if (arg === "clear" || arg === "off" || arg === "--clear") {
+    await setUserdata("apn-snooze", null);
+    console.log("Snooze cleared");
+    return;
+  }
+
+  const date = new Date(arg);
+  if (isNaN(date.getTime())) {
+    console.error(`Invalid date: ${arg}`);
+    process.exit(1);
+  }
+  const iso = date.toISOString();
+  await setUserdata("apn-snooze", { until: iso });
+  console.log(
+    `Snoozing non-low notifications until ${iso} (${formatLocal(date)}, ${formatDuration(date.getTime() - Date.now())} from now)`,
+  );
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Add notification when still in low even though no new changing BG was received — either the sensor is faulty and does not register new values, or the BG is not moving and we're staying low.